### PR TITLE
Stop using keyword arguments

### DIFF
--- a/csv2md.gemspec
+++ b/csv2md.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name        = "csv2md"
-  spec.version     = "1.1.0"
+  spec.version     = "1.1.1"
   spec.date        = "2015-04-29"
   spec.summary     = "Convert csv into a GitHub Flavored Markdown table"
   spec.description = "Convert csv into a GitHub Flavored Markdown table"

--- a/lib/csv2md.rb
+++ b/lib/csv2md.rb
@@ -3,7 +3,7 @@ require "csv"
 class Csv2md
   class UnableToParseCsv < StandardError; end
 
-  def initialize(input: nil)
+  def initialize(input)
     @input = input
   end
 

--- a/test/lib/csv2md_test.rb
+++ b/test/lib/csv2md_test.rb
@@ -3,13 +3,13 @@ require_relative "../test_helper"
 class Csv2mdTest < Minitest::Test
   def test_find_column_widths_returns_array_of_column_widths
     csv = File.read(fixture_path_helper("sample.csv"))
-    subject = Csv2md.new(input: csv)
+    subject = Csv2md.new(csv)
     assert_equal [12, 5, 14], subject.find_column_widths
   end
 
   def test_find_column_widths_raises_error_with_malformed_data
     csv = File.read(fixture_path_helper("malformed.csv"))
-    subject = Csv2md.new(input: csv)
+    subject = Csv2md.new(csv)
     assert_raises(Csv2md::UnableToParseCsv) do
       subject.find_column_widths
     end
@@ -18,14 +18,14 @@ class Csv2mdTest < Minitest::Test
   def test_gfm_returns_csv_converted_to_pretty_gfm_table
     csv = File.read(fixture_path_helper("sample.csv"))
     expected = File.read(fixture_path_helper("sample.md"))
-    subject = Csv2md.new(input: csv)
+    subject = Csv2md.new(csv)
     assert_equal expected, subject.gfm
   end
 
   def test_csv_returns_gfm_table_converted_to_csv
     md = File.read(fixture_path_helper("sample.md"))
     expected = File.read(fixture_path_helper("sample.csv"))
-    subject = Csv2md.new(input: md)
+    subject = Csv2md.new(md)
     assert_equal expected, subject.csv
   end
 end


### PR DESCRIPTION
This makes csv2md work with ruby versions < 2.0.0.

Fixes #1 

/cc @skypanther