### PR TITLE
Several fixes

### DIFF
--- a/bin/csv2md
+++ b/bin/csv2md
@@ -29,7 +29,7 @@ begin
   else
     while file_path = ARGV.shift
       input = File.read(file_path)
-      csv2md = Csv2md.new(input: input)
+      csv2md = Csv2md.new(input)
       gfm += csv2md.send(output_format)
       gfm += "\n" if ARGV.length > 0
     end

--- a/lib/csv2md.rb
+++ b/lib/csv2md.rb
@@ -49,7 +49,7 @@ class Csv2md
 
   def csv
     result = input.split("\n").map do |line|
-      row = line.scan(/\|([^\|]+)\s/).flatten.map(&:strip).join(",")
+      row = line.scan(/\|([^\|]*)\s/).flatten.map(&:strip).join(",")
       row unless row.strip == ""
     end.compact.join("\n")
     result += "\n"

--- a/lib/csv2md.rb
+++ b/lib/csv2md.rb
@@ -12,7 +12,7 @@ class Csv2md
   def find_column_widths
     parsed_csv.inject(Array.new(parsed_csv[0].length, 0)) do |result, line|
       line.each_with_index do |column, i|
-        if column.length > result[i]
+        if column.to_s.length > result[i]
           result[i] = column.length
         end
       end
@@ -31,7 +31,7 @@ class Csv2md
     parsed_csv.each_with_index do |line, row_index|
       line.each_with_index do |column, column_index|
         result += "| "
-        result += column.ljust(widths[column_index] + 1, " ")
+        result += column.to_s.ljust(widths[column_index] + 1, " ")
         if column_index == number_of_columns - 1
           result += "|\n"
         end


### PR DESCRIPTION
Several fixes:
1. Fix for `nil` columns - `nil` doesn't have `length` and `ljust` methods
   `> CSV.parse('0,,1') # => [["0", nil, "1"]]`
2. md->CSV conversion doesn't properly handle empty columns
    F.ex. row `| 0 | 1 | | 0 |` was converted to `0,1,0` instead of `0,1,,0`
3. Fixed the bin script to initialise `Csv2md` with input as plain variable instead of hash in the `-r` mode 